### PR TITLE
calculate state root always in the last flashblock, regardless of config

### DIFF
--- a/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -390,7 +390,10 @@ where
                     });
 
                     let total_block_built_duration = Instant::now();
-                    let build_result = build_block(db, &ctx, &mut info, calculate_state_root);
+                    let should_calculate_state_root =
+                        calculate_state_root || flashblock_count == last_flashblock;
+                    let build_result =
+                        build_block(db, &ctx, &mut info, should_calculate_state_root);
                     ctx.metrics
                         .total_block_built_duration
                         .record(total_block_built_duration.elapsed());


### PR DESCRIPTION
works in conjunction with https://github.com/base/rollup-boost/pull/11