### PR TITLE
fix: handle EVM errors gracefully in backrun bundle execution

### DIFF
--- a/crates/op-rbuilder/src/builders/context.rs
+++ b/crates/op-rbuilder/src/builders/context.rs
@@ -678,8 +678,7 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
                         let ResultAndState { result, state } = match evm.transact(&consensus_tx) {
                             Ok(res) => res,
                             Err(err) => {
-                                // Handle EVM errors gracefully - skip the bundle instead of failing the block
-                                self.metrics.backrun_bundles_reverted_total.increment(1);
+                                self.metrics.backrun_bundles_evm_error_total.increment(1);
                                 info!(
                                     target: "payload_builder",
                                     target_tx = ?tx_hash,

--- a/crates/op-rbuilder/src/builders/context.rs
+++ b/crates/op-rbuilder/src/builders/context.rs
@@ -678,16 +678,20 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
                         let ResultAndState { result, state } = match evm.transact(&consensus_tx) {
                             Ok(res) => res,
                             Err(err) => {
-                                self.metrics.backrun_bundles_evm_error_total.increment(1);
-                                info!(
-                                    target: "payload_builder",
-                                    target_tx = ?tx_hash,
-                                    failed_tx = ?backrun_tx.hash(),
-                                    bundle_id = ?stored_bundle.bundle_id,
-                                    error = %err,
-                                    "Backrun bundle failed with EVM error"
-                                );
-                                continue 'bundle_loop;
+                                if err.as_invalid_tx_err().is_some() {
+                                    self.metrics.backrun_bundles_invalid_tx_total.increment(1);
+                                    info!(
+                                        target: "payload_builder",
+                                        target_tx = ?tx_hash,
+                                        failed_tx = ?backrun_tx.hash(),
+                                        bundle_id = ?stored_bundle.bundle_id,
+                                        error = %err,
+                                        "Backrun bundle failed with invalid tx error"
+                                    );
+                                    continue 'bundle_loop;
+                                }
+                                self.metrics.backrun_bundles_fatal_error_total.increment(1);
+                                return Err(PayloadBuilderError::evm(err));
                             }
                         };
 

--- a/crates/op-rbuilder/src/metrics.rs
+++ b/crates/op-rbuilder/src/metrics.rs
@@ -175,8 +175,10 @@ pub struct OpRBuilderMetrics {
     pub backrun_bundles_received_total: Counter,
     /// Number of backrun bundles that reverted during execution (all-or-nothing)
     pub backrun_bundles_reverted_total: Counter,
-    /// Number of backrun bundles that failed with EVM errors (nonce too low, invalid tx, etc.)
-    pub backrun_bundles_evm_error_total: Counter,
+    /// Number of backrun bundles skipped due to invalid tx errors (nonce too low, etc.)
+    pub backrun_bundles_invalid_tx_total: Counter,
+    /// Number of backrun bundles that caused fatal EVM errors
+    pub backrun_bundles_fatal_error_total: Counter,
     /// Number of backrun bundles rejected due to priority fee below target tx
     pub backrun_bundles_rejected_low_fee_total: Counter,
     /// Number of backrun bundles rejected due to exceeding block limits

--- a/crates/op-rbuilder/src/metrics.rs
+++ b/crates/op-rbuilder/src/metrics.rs
@@ -175,6 +175,8 @@ pub struct OpRBuilderMetrics {
     pub backrun_bundles_received_total: Counter,
     /// Number of backrun bundles that reverted during execution (all-or-nothing)
     pub backrun_bundles_reverted_total: Counter,
+    /// Number of backrun bundles that failed with EVM errors (nonce too low, invalid tx, etc.)
+    pub backrun_bundles_evm_error_total: Counter,
     /// Number of backrun bundles rejected due to priority fee below target tx
     pub backrun_bundles_rejected_low_fee_total: Counter,
     /// Number of backrun bundles rejected due to exceeding block limits

--- a/crates/op-rbuilder/src/tests/backrun.rs
+++ b/crates/op-rbuilder/src/tests/backrun.rs
@@ -561,16 +561,12 @@ async fn backrun_bundle_rejected_exceeds_da_limit(rbuilder: LocalInstance) -> ey
     Ok(())
 }
 
-/// Tests that backrun bundles with EVM errors (not reverts) are skipped gracefully
-/// instead of failing the entire block build.
-/// This covers errors like nonce-too-low which return Err from evm.transact()
-/// rather than Ok with a failed result.
+/// Tests that backrun bundles with EVM errors are skipped gracefully instead of failing block build
 #[rb_test(flashblocks)]
 async fn backrun_bundle_evm_error_skipped(rbuilder: LocalInstance) -> eyre::Result<()> {
     let driver = rbuilder.driver().await?;
     let accounts = driver.fund_accounts(3, ONE_ETH).await?;
 
-    // 1. Build target tx
     let target_tx = driver
         .create_transaction()
         .with_signer(accounts[0])
@@ -584,7 +580,6 @@ async fn backrun_bundle_evm_error_skipped(rbuilder: LocalInstance) -> eyre::Resu
         .send_raw_transaction(target_tx.encoded_2718().as_slice())
         .await?;
 
-    // 2. Create a backrun tx from accounts[1] with nonce 0
     let backrun_tx = driver
         .create_transaction()
         .with_signer(accounts[1])
@@ -594,18 +589,16 @@ async fn backrun_bundle_evm_error_skipped(rbuilder: LocalInstance) -> eyre::Resu
         .await;
     let backrun_tx_hash = backrun_tx.tx_hash().clone();
 
-    // 3. Also send a DIFFERENT tx from accounts[1] with nonce 0 to the mempool
-    //    This tx will be included first, making the backrun's nonce stale
+    // Send a conflicting tx with same nonce but higher fee - it will be included first
     let conflicting_tx = driver
         .create_transaction()
         .with_signer(accounts[1])
-        .with_max_priority_fee_per_gas(100) // Higher fee so it's picked first
+        .with_max_priority_fee_per_gas(100)
         .with_nonce(0)
         .send()
         .await?;
     let conflicting_tx_hash = conflicting_tx.tx_hash().clone();
 
-    // 4. Insert backrun bundle targeting our target tx
     let bundle = AcceptedBundle {
         uuid: Uuid::new_v4(),
         txs: vec![target_tx, backrun_tx],
@@ -636,26 +629,21 @@ async fn backrun_bundle_evm_error_skipped(rbuilder: LocalInstance) -> eyre::Resu
         .insert_backrun_bundle(bundle)
         .expect("Failed to insert backrun bundle");
 
-    // 5. Build the block - this should NOT fail even though backrun has invalid nonce
     driver.build_new_block().await?;
 
-    // 6. Verify block contents
     let block = driver.latest_full().await?;
     let tx_hashes: Vec<_> = block.transactions.hashes().collect();
 
-    // Target tx should be in block
     assert!(
         tx_hashes.contains(&target_tx_hash),
         "Target tx should be included in block"
     );
 
-    // Conflicting tx (from mempool) should be in block
     assert!(
         tx_hashes.contains(&conflicting_tx_hash),
         "Conflicting tx should be included in block"
     );
 
-    // Backrun tx should NOT be in block (nonce already used by conflicting tx)
     assert!(
         !tx_hashes.contains(&backrun_tx_hash),
         "Backrun tx should NOT be in block (nonce-too-low EVM error)"

--- a/crates/op-rbuilder/src/tests/backrun.rs
+++ b/crates/op-rbuilder/src/tests/backrun.rs
@@ -561,9 +561,9 @@ async fn backrun_bundle_rejected_exceeds_da_limit(rbuilder: LocalInstance) -> ey
     Ok(())
 }
 
-/// Tests that backrun bundles with EVM errors are skipped gracefully instead of failing block build
+/// Tests that backrun bundles with invalid tx errors (e.g. nonce too low) are skipped gracefully
 #[rb_test(flashblocks)]
-async fn backrun_bundle_evm_error_skipped(rbuilder: LocalInstance) -> eyre::Result<()> {
+async fn backrun_bundle_invalid_tx_skipped(rbuilder: LocalInstance) -> eyre::Result<()> {
     let driver = rbuilder.driver().await?;
     let accounts = driver.fund_accounts(3, ONE_ETH).await?;
 


### PR DESCRIPTION
Description:
Backrun bundles with EVM errors (e.g., nonce too low) could cause block building to fail entirely. Now these errors are caught and the bundle is skipped, allowing block building to continue.
Changes:
- Skip bundles on EVM errors instead of returning Err
- Add backrun_bundles_evm_error_total metric
- Add test case for EVM error handling
