### PR TITLE
feat: don't send receipts in flashblocks websocket

### DIFF
--- a/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -16,7 +16,7 @@ use alloy_consensus::{
     BlockBody, EMPTY_OMMER_ROOT_HASH, Header, constants::EMPTY_WITHDRAWALS, proofs,
 };
 use alloy_eips::{Encodable2718, eip7685::EMPTY_REQUESTS_HASH, merge::BEACON_NONCE};
-use alloy_primitives::{Address, B256, U256, map::foldhash::HashMap};
+use alloy_primitives::{B256, U256};
 use core::time::Duration;
 use eyre::WrapErr as _;
 use reth::payload::PayloadBuilderAttributes;
@@ -24,12 +24,12 @@ use reth_basic_payload_builder::BuildOutcome;
 use reth_chain_state::ExecutedBlock;
 use reth_chainspec::EthChainSpec;
 use reth_evm::{ConfigureEvm, execute::BlockBuilder};
-use reth_node_api::{Block, NodePrimitives, PayloadBuilderError};
+use reth_node_api::{Block, PayloadBuilderError};
 use reth_optimism_consensus::{calculate_receipt_root_no_memo_optimism, isthmus};
 use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_node::{OpBuiltPayload, OpPayloadBuilderAttributes};
-use reth_optimism_primitives::{OpPrimitives, OpTransactionSigned};
+use reth_optimism_primitives::OpTransactionSigned;
 use reth_payload_util::BestPayloadTransactions;
 use reth_primitives_traits::RecoveredBlock;
 use reth_provider::{
@@ -942,8 +942,6 @@ where
 
 #[derive(Debug, Serialize, Deserialize)]
 struct FlashblocksMetadata {
-    receipts: Option<HashMap<B256, <OpPrimitives as NodePrimitives>::Receipt>>,
-    new_account_balances: HashMap<Address, U256>,
     block_number: u64,
 }
 
@@ -1135,16 +1133,8 @@ where
         .collect::<Vec<_>>();
 
     info.extra.last_flashblock_index = info.executed_transactions.len();
-    let new_account_balances = state
-        .bundle_state
-        .state
-        .iter()
-        .filter_map(|(address, account)| account.info.as_ref().map(|info| (*address, info.balance)))
-        .collect::<HashMap<Address, U256>>();
 
     let metadata: FlashblocksMetadata = FlashblocksMetadata {
-        receipts: None,
-        new_account_balances,
         block_number: ctx.parent().number + 1,
     };
 

--- a/crates/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -29,7 +29,7 @@ use reth_optimism_consensus::{calculate_receipt_root_no_memo_optimism, isthmus};
 use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_node::{OpBuiltPayload, OpPayloadBuilderAttributes};
-use reth_optimism_primitives::{OpPrimitives, OpReceipt, OpTransactionSigned};
+use reth_optimism_primitives::{OpPrimitives, OpTransactionSigned};
 use reth_payload_util::BestPayloadTransactions;
 use reth_primitives_traits::RecoveredBlock;
 use reth_provider::{
@@ -942,7 +942,7 @@ where
 
 #[derive(Debug, Serialize, Deserialize)]
 struct FlashblocksMetadata {
-    receipts: HashMap<B256, <OpPrimitives as NodePrimitives>::Receipt>,
+    receipts: Option<HashMap<B256, <OpPrimitives as NodePrimitives>::Receipt>>,
     new_account_balances: HashMap<Address, U256>,
     block_number: u64,
 }
@@ -1134,13 +1134,7 @@ where
         .map(|tx| tx.encoded_2718().into())
         .collect::<Vec<_>>();
 
-    let new_receipts = info.receipts[info.extra.last_flashblock_index..].to_vec();
     info.extra.last_flashblock_index = info.executed_transactions.len();
-    let receipts_with_hash = new_transactions
-        .iter()
-        .zip(new_receipts.iter())
-        .map(|(tx, receipt)| (tx.tx_hash(), receipt.clone()))
-        .collect::<HashMap<B256, OpReceipt>>();
     let new_account_balances = state
         .bundle_state
         .state
@@ -1149,7 +1143,7 @@ where
         .collect::<HashMap<Address, U256>>();
 
     let metadata: FlashblocksMetadata = FlashblocksMetadata {
-        receipts: receipts_with_hash,
+        receipts: None,
         new_account_balances,
         block_number: ctx.parent().number + 1,
     };

--- a/crates/op-rbuilder/src/tests/framework/instance.rs
+++ b/crates/op-rbuilder/src/tests/framework/instance.rs
@@ -448,24 +448,23 @@ impl FlashblocksListener {
 
     /// Check if any flashblock contains the given transaction hash
     pub fn contains_transaction(&self, tx_hash: &B256) -> bool {
-        let tx_hash_str = format!("{tx_hash:#x}");
         self.flashblocks.lock().iter().any(|fb| {
-            if let Some(receipts) = fb.metadata.get("receipts")
-                && let Some(receipts_obj) = receipts.as_object()
-            {
-                return receipts_obj.contains_key(&tx_hash_str);
-            }
-            false
+            fb.diff
+                .transactions
+                .iter()
+                .any(|tx| keccak256(tx) == *tx_hash)
         })
     }
 
     /// Find which flashblock index contains the given transaction hash
     pub fn find_transaction_flashblock(&self, tx_hash: &B256) -> Option<u64> {
-        let tx_hash_str = format!("{tx_hash:#x}");
         self.flashblocks.lock().iter().find_map(|fb| {
-            if let Some(receipts) = fb.metadata.get("receipts")
-                && let Some(receipts_obj) = receipts.as_object()
-                && receipts_obj.contains_key(&tx_hash_str)
+            if fb
+                .diff
+                .transactions
+                .iter()
+                .find(|tx| keccak256(tx) == *tx_hash)
+                .is_some()
             {
                 return Some(fb.index);
             }


### PR DESCRIPTION
⚠️  NOTE: This is a breaking change to the flashblocks websocket API. This is not ready to merge yet since we need to give sufficient heads up (2-4 weeks) to consumers of the stream after https://github.com/base/node-reth/pull/300 is released.


## 📝 Summary

<!--- A general summary of your changes -->

Removes receipts from the flashblocks websocket stream. These were only used for deposit transactions' nonces and aren't worth the large overhead.

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
